### PR TITLE
Switch to using hostnames

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM stackbrew/ubuntu:13.10
-MAINTAINER Roman Atachiants "roman@misakai.com"
+FROM stackbrew/ubuntu:14.04
+MAINTAINER Carson Darling "carsondarling@gmail.com"
 
 RUN apt-get update -qq
 RUN apt-get install -y python-boto python-requests

--- a/README.md
+++ b/README.md
@@ -1,13 +1,38 @@
 # EC2 Route53 Presence for Docker
 
-Docker container which registers the local ec2 instance into route53. 
+Docker container which registers the local EC2 instance into Route53.
 
 Example of usage:
-```
+
+```bash
 docker run --name route53-presence  \
           -e HOSTNAME_PUBLIC=some.example.com  \
-          -e HOSTNAME_LOCAL=local.some.example.com  \
           -e AWS_ACCESS_KEY=XXX \
           -e AWS_SECRET_KEY=XXX  \
-          misakai/route53-presence
+          carsondarling/docker-route53-presence
+```
+
+In addition, the AWS credentials can be ommited, if the host has a valid IAM role that allows for the following permissions:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": "arn:aws:route53:::hostedzone/<ZONEID>"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ListHostedZones"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
 ```

--- a/bin/route53-presence
+++ b/bin/route53-presence
@@ -20,28 +20,20 @@ def get_zone_id(hostname):
     exit(1)
   return zone.GetHostedZoneResponse.Id.split('/')[2]
 
-def get_local_ip():
-  return requests.get("http://169.254.169.254/latest/meta-data/local-ipv4").content
-  
-def get_public_ip():
-  return requests.get("http://169.254.169.254/latest/meta-data/public-ipv4").content
+def get_public_hostname():
+  return requests.get("http://169.254.169.254/latest/meta-data/public-hostname").content
 
-def register(hostname, ip, ttl):
+def register(hostname, instance_hostname, ttl):
   changes = ResourceRecordSets(conn, zone_id)
-  change = changes.add_change('UPSERT', hostname, 'A', ttl)
-  change.add_value(ip)
+  change = changes.add_change('UPSERT', hostname, 'CNAME', ttl)
+  change.add_value(instance_hostname)
   return changes.commit()
 
-hostname_local  = os.environ.get('HOSTNAME_LOCAL')
 hostname_public = os.environ.get('HOSTNAME_PUBLIC')
 conn = boto.connect_route53(os.environ.get('AWS_ACCESS_KEY'), os.environ.get('AWS_SECRET_KEY'))
-zone_id = get_zone_id(hostname_local)
+zone_id = get_zone_id(hostname_public)
 
-result_local = register(hostname_local, get_local_ip(), 600)
-if not result_local:
-  exit(1)
-
-result_public = register(hostname_public, get_public_ip(), 600)
+result_public = register(hostname_public, get_public_hostname(), 60)
 if not result_public:
   exit(1)
 


### PR DESCRIPTION
This change switches to using a CNAME record with the instance's hostname, instead of it's public and private IPs. It also updates to Ubuntu 14.04, since the packages for 13.10 were no longer resolving (Ubuntu no longer supports 13.10).
