### PR TITLE
Resubmission: Allow zone detection of domains lower than 2nd level

### DIFF
--- a/bin/route53-presence
+++ b/bin/route53-presence
@@ -13,7 +13,7 @@ from boto.route53.record import ResourceRecordSets
 import requests
 
 def get_zone_id(hostname):
-  domainname = '.'.join(hostname.split('.')[-2:])
+  domainname = '.'.join(hostname.split('.')[1:])
   zone = conn.get_hosted_zone_by_name(domainname)
   if not zone:
     print "Sorry, you don't have access to that domain!"


### PR DESCRIPTION
The original code assumed 2nd level domain hosted zones, eg. example.com, and the hostnames getting registered in Route 53 were of the form foobar.example.com and couldn't handle lower level domains like sub.example.com with hostnames like foobar.sub.example.com. This change will allow for that.
